### PR TITLE
Added support for Directory.Packages.props (Central Package Management)

### DIFF
--- a/src/LibYear.Core/FileTypes/DirectoryPackagesPropsFile.cs
+++ b/src/LibYear.Core/FileTypes/DirectoryPackagesPropsFile.cs
@@ -1,0 +1,8 @@
+namespace LibYear.Core.FileTypes;
+
+public class DirectoryPackagesPropsFile : XmlProjectFile
+{
+	public DirectoryPackagesPropsFile(string filename, string contents) : base(filename, contents, "PackageVersion", new[] { "Include", "Update" }, "Version")
+	{
+	}
+}

--- a/src/LibYear.Core/ProjectFileManager.cs
+++ b/src/LibYear.Core/ProjectFileManager.cs
@@ -1,6 +1,5 @@
-using System.IO.Abstractions;
-using System.Text;
 using LibYear.Core.FileTypes;
+using System.IO.Abstractions;
 
 namespace LibYear.Core;
 
@@ -49,6 +48,7 @@ public class ProjectFileManager : IProjectFileManager
 			.Union(dir.EnumerateFiles("Directory.build.props", searchMode))
 			.Union(dir.EnumerateFiles("Directory.build.targets", searchMode))
 			.Union(dir.EnumerateFiles("packages.config", searchMode))
+			.Union(dir.EnumerateFiles("Directory.packages.props", searchMode))
 			.Select(ReadFile)
 			.ToArray();
 
@@ -56,6 +56,7 @@ public class ProjectFileManager : IProjectFileManager
 	private static bool IsDirectoryBuildPropsFile(IFileSystemInfo fileInfo) => fileInfo.Name == "Directory.Build.props";
 	private static bool IsDirectoryBuildTargetsFile(IFileSystemInfo fileInfo) => fileInfo.Name == "Directory.Build.targets";
 	private static bool IsNuGetFile(IFileSystemInfo fileInfo) => fileInfo.Name == "packages.config";
+	private static bool IsDirectoryPackagesPropsFile(IFileSystemInfo fileInfo) => fileInfo.Name == "Directory.Packages.props";
 
 	private async Task<IProjectFile> ReadFile(IFileSystemInfo fileInfo)
 	{
@@ -72,6 +73,8 @@ public class ProjectFileManager : IProjectFileManager
 			return new DirectoryBuildTargetsFile(path, contents);
 		if (IsNuGetFile(fileInfo))
 			return new PackagesConfigFile(path, contents);
+		if (IsDirectoryPackagesPropsFile(fileInfo))
+			return new DirectoryPackagesPropsFile(path, contents);
 
 		throw new NotImplementedException("Unknown file type");
 	}

--- a/test/LibYear.Core.Tests/FileTypes/Directory.Packages.props
+++ b/test/LibYear.Core.Tests/FileTypes/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageVersion Include="test1" Version="0.1.0" />
+		<PackageVersion Update="test2" Version="0.2.0" />
+		<PackageVersion>
+			<Update>test3</Update>
+			<Version>0.3.0</Version>
+		</PackageVersion>
+	</ItemGroup>
+</Project>

--- a/test/LibYear.Core.Tests/FileTypes/DirectoryPackagesPropsTests.cs
+++ b/test/LibYear.Core.Tests/FileTypes/DirectoryPackagesPropsTests.cs
@@ -1,0 +1,68 @@
+using LibYear.Core.FileTypes;
+using Xunit;
+
+namespace LibYear.Core.Tests.FileTypes;
+
+public class DirectoryPackagesPropsTests
+{
+	[Fact]
+	public async Task CanLoadDirectoryPackagesPropsFile()
+	{
+		//arrange
+		var filename = Path.Combine("FileTypes", "Directory.Packages.props");
+
+		//act
+		var file = new DirectoryPackagesPropsFile(filename, await File.ReadAllTextAsync(filename));
+
+		//assert
+		Assert.Equal("test1", file.Packages.First().Key);
+		Assert.Equal("test2", file.Packages.Skip(1).First().Key);
+		Assert.Equal("test3", file.Packages.Skip(2).First().Key);
+	}
+
+	[Fact]
+	public async Task CanUpdateDirectoryPackagesPropsFile()
+	{
+		//arrange
+		var filename = Path.Combine("FileTypes", "Directory.Packages.props");
+		var file = new DirectoryPackagesPropsFile(filename, await File.ReadAllTextAsync(filename));
+		var results = new[]
+		{
+			new Result("test1", new Release(new PackageVersion(0, 1, 0), DateTime.Today), new Release(new PackageVersion(1, 2, 3), DateTime.Today)),
+			new Result("test2", new Release(new PackageVersion(0, 2, 0), DateTime.Today), new Release(new PackageVersion(2, 3, 4), DateTime.Today)),
+			new Result("test3", new Release(new PackageVersion(0, 3, 0), DateTime.Today), new Release(new PackageVersion(3, 4, 5), DateTime.Today))
+		};
+
+		//act
+		var updated = file.Update(results);
+
+		//assert
+		var newFile = new DirectoryPackagesPropsFile(filename, updated);
+		Assert.Equal("1.2.3", newFile.Packages.First().Value!.ToString());
+		Assert.Equal("2.3.4", newFile.Packages.Skip(1).First().Value!.ToString());
+		Assert.Equal("3.4.5", newFile.Packages.Skip(2).First().Value!.ToString());
+	}
+
+	[Fact]
+	public async Task InvalidVersionShowsInfo()
+	{
+		//arrange
+		var filename = Path.Combine("FileTypes", "Directory.Packages.props");
+		var contents = await File.ReadAllTextAsync(filename);
+		var newContents = contents.Replace("0.2.0", "0.2.x");
+
+		try
+		{
+			//act
+			_ = new DirectoryPackagesPropsFile(filename, newContents);
+			Assert.False(true);
+		}
+		catch (Exception e)
+		{
+			//assert
+			Assert.Contains("0.2.x", e.Message);
+			Assert.Contains("test2", e.Message);
+			Assert.Contains("Directory.Packages.props", e.Message);
+		}
+	}
+}

--- a/test/LibYear.Core.Tests/LibYear.Core.Tests.csproj
+++ b/test/LibYear.Core.Tests/LibYear.Core.Tests.csproj
@@ -18,4 +18,9 @@
 		<None Include="FileTypes/Directory.Build.props" CopyToOutputDirectory="Always" />
 		<None Include="FileTypes/Directory.Build.targets" CopyToOutputDirectory="Always" />
 	</ItemGroup>
+	<ItemGroup>
+	  <None Update="FileTypes\Directory.Packages.props">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
The tool did not support reading Directory.Packages.props that is used for [Central Package management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management).